### PR TITLE
feat: add theme provider and toggle

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import { ChatList } from "@/components/chat-list";
 import { ChatWindow } from "@/components/chat-window";
 import { UserManagement } from "@/components/user-management";
 import { InstanceSettings } from "@/components/instance-setting";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 interface Chat {
   id: string;
@@ -136,6 +137,7 @@ export default function DashboardPage() {
                 <p className="text-sm font-medium text-foreground">Olá, {user.name}</p>
                 <p className="text-xs text-muted-foreground">Bem-vindo de volta</p>
               </div>
+              <ThemeToggle />
               <Button
                 variant="outline"
                 size="sm"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google"
 import "./globals.css"
 import { Toaster } from "sonner"
 import { AuthProvider }from "@/components/auth-provider"
+import { ThemeProvider } from "@/components/theme-provider"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -18,12 +19,14 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="pt-BR" className="ligth root">
+    <html lang="pt-BR" suppressHydrationWarning>
       <body className={inter.className}>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <AuthProvider>
             {children}
             <Toaster />
           </AuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+import type { ThemeProviderProps } from "next-themes"
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem {...props}>
+      {children}
+    </NextThemesProvider>
+  )
+}
+

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import * as React from "react"
+import { Moon, Sun } from "lucide-react"
+import { useTheme } from "next-themes"
+
+import { Button } from "@/components/ui/button"
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => setMounted(true), [])
+
+  if (!mounted) {
+    return (
+      <Button variant="outline" size="icon">
+        <Sun className="h-[1.2rem] w-[1.2rem]" />
+        <span className="sr-only">Toggle theme</span>
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+    >
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add `ThemeProvider` using `next-themes`
- enable system theme switching in layout
- add `ThemeToggle` component and integrate into dashboard header

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68956bf21948832db9743c896d7a6dae