### PR TITLE
Fix audio player playback

### DIFF
--- a/src/components/audio-player.tsx
+++ b/src/components/audio-player.tsx
@@ -34,11 +34,18 @@ export function AudioPlayer({ src, title, isOpen, onClose, caption }: AudioPlaye
       setCurrentTime(0)
       setError(null)
       setIsLoading(true)
+      // Ensure the audio element reloads when the dialog opens
+      if (audioRef.current) {
+        audioRef.current.load()
+      }
+    } else if (audioRef.current) {
+      audioRef.current.pause()
     }
   }, [isOpen])
 
   // Audio event listeners
   useEffect(() => {
+    if (!isOpen) return
     const audio = audioRef.current
     if (!audio) return
 
@@ -80,7 +87,7 @@ export function AudioPlayer({ src, title, isOpen, onClose, caption }: AudioPlaye
       audio.removeEventListener("error", handleError)
       audio.removeEventListener("canplay", handleCanPlay)
     }
-  }, [isLooping])
+  }, [isOpen, isLooping, src])
 
   // Keyboard shortcuts
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Reload audio element on open and pause when closed
- Attach audio event listeners only when the player dialog is open

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6895f9a3ef78832da127e955009781d2