### PR TITLE
Handle media uploads and keep message input focused

### DIFF
--- a/src/app/api/messages/[id]/send-media/route.ts
+++ b/src/app/api/messages/[id]/send-media/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server"
+
+const EVOLUTION_API_BASE_URL = process.env.EVOLUTION_API_BASE_URL || "http://localhost:8080"
+const EVOLUTION_API_KEY = process.env.EVOLUTION_API_KEY
+const INSTANCE_NAME = process.env.INSTANCE_NAME || "joaoomni"
+
+type RouterContext = {
+  params: Promise<{ id: string }>
+}
+
+export async function POST(request: Request, context: RouterContext): Promise<NextResponse> {
+  const params = await context.params
+  const phoneNumber = params.id
+
+  try {
+    const formData = await request.formData()
+    const file = formData.get("file") as File | null
+    const caption = (formData.get("caption") as string) || ""
+
+    if (!file) {
+      return NextResponse.json({ error: "Arquivo não encontrado" }, { status: 400 })
+    }
+
+    const arrayBuffer = await file.arrayBuffer()
+    const base64 = Buffer.from(arrayBuffer).toString("base64")
+
+    let mediatype = "document"
+    if (file.type.startsWith("image/")) mediatype = "image"
+    else if (file.type.startsWith("audio/")) mediatype = "audio"
+    else if (file.type.startsWith("video/")) mediatype = "video"
+
+    const evolutionResponse = await fetch(`${EVOLUTION_API_BASE_URL}/message/sendMedia/${INSTANCE_NAME}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(EVOLUTION_API_KEY ? { apikey: EVOLUTION_API_KEY } : {}),
+      },
+      body: JSON.stringify({
+        number: phoneNumber,
+        options: {
+          delay: 123,
+          presence: "composing",
+        },
+        mediaMessage: {
+          mediatype,
+          caption,
+          fileName: file.name,
+          media: base64,
+        },
+      }),
+    })
+
+    if (!evolutionResponse.ok) {
+      const errorText = await evolutionResponse.text()
+      console.error("Failed to send media via Evolution API:", errorText)
+      throw new Error("Failed to send media via Evolution API")
+    }
+
+    const evolutionData = await evolutionResponse.json()
+    return NextResponse.json({ success: true, data: evolutionData })
+  } catch (error) {
+    console.error("Failed to send media:", error)
+    return NextResponse.json({ error: "Erro ao enviar mídia" }, { status: 500 })
+  }
+}

--- a/src/app/api/messages/[id]/send-media/route.ts
+++ b/src/app/api/messages/[id]/send-media/route.ts
@@ -29,26 +29,24 @@ export async function POST(request: Request, context: RouterContext): Promise<Ne
     else if (file.type.startsWith("audio/")) mediatype = "audio"
     else if (file.type.startsWith("video/")) mediatype = "video"
 
-    const evolutionResponse = await fetch(`${EVOLUTION_API_BASE_URL}/message/sendMedia/${INSTANCE_NAME}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(EVOLUTION_API_KEY ? { apikey: EVOLUTION_API_KEY } : {}),
-      },
-      body: JSON.stringify({
-        number: phoneNumber,
-        options: {
-          delay: 123,
-          presence: "composing",
+    const evolutionResponse = await fetch(
+      `${EVOLUTION_API_BASE_URL}/message/sendMedia/${INSTANCE_NAME}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(EVOLUTION_API_KEY ? { apikey: EVOLUTION_API_KEY } : {}),
         },
-        mediaMessage: {
+        body: JSON.stringify({
+          number: phoneNumber,
           mediatype,
+          mimetype: file.type,
           caption,
-          fileName: file.name,
           media: base64,
-        },
-      }),
-    })
+          fileName: file.name,
+        }),
+      }
+    )
 
     if (!evolutionResponse.ok) {
       const errorText = await evolutionResponse.text()

--- a/src/components/chat-window.tsx
+++ b/src/components/chat-window.tsx
@@ -73,6 +73,7 @@ export function ChatWindow({ chat, onChatUpdate, lastPusherEvent }: ChatWindowPr
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const scrollAreaRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [shouldScrollToBottom, setShouldScrollToBottom] = useState(true)
   const [showImageViewer, setShowImageViewer] = useState(false)
   const [selectedImage, setSelectedImage] = useState<{ src: string; alt: string; caption?: string } | null>(null)
@@ -292,7 +293,6 @@ export function ChatWindow({ chat, onChatUpdate, lastPusherEvent }: ChatWindowPr
     }
 
     setMessages((prev) => [...prev, optimisticMessage])
-    setNewMessage("")
     setShouldScrollToBottom(true)
 
     try {
@@ -316,7 +316,6 @@ export function ChatWindow({ chat, onChatUpdate, lastPusherEvent }: ChatWindowPr
       const responseData = await response.json()
 
       if (response.ok) {
-        toast.success("Mensagem enviada com sucesso")
         setMessages((prev) =>
           prev.map((msg) => (msg.id === optimisticId ? { ...msg, id: responseData.data.key.id } : msg)),
         )
@@ -334,6 +333,7 @@ export function ChatWindow({ chat, onChatUpdate, lastPusherEvent }: ChatWindowPr
       if (file && optimisticMessage.mediaUrl) {
         URL.revokeObjectURL(optimisticMessage.mediaUrl)
       }
+      textareaRef.current?.focus()
     }
   }
 
@@ -701,6 +701,7 @@ export function ChatWindow({ chat, onChatUpdate, lastPusherEvent }: ChatWindowPr
           <div className="flex items-end space-x-2">
             <div className="flex-1">
               <Textarea
+                ref={textareaRef}
                 placeholder="Digite sua mensagem..."
                 value={newMessage}
                 onChange={(e) => setNewMessage(e.target.value)}


### PR DESCRIPTION
## Summary
- add API route to forward media messages to Evolution API
- keep chat text in the input and avoid success toast

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_6896237dc21c832db7b3752a8156f404